### PR TITLE
Add minimum argument: -m or --min

### DIFF
--- a/sparklines/__main__.py
+++ b/sparklines/__main__.py
@@ -81,8 +81,11 @@ def main():
     p.add_argument('-d', '--demo', action='store_true',
         help='Show a few usage examples for given (mandatory) input values.')
 
+    p.add_argument('-m', '--min', type=float,
+        help='Use this value as the minimum for scaling')
+
     p.add_argument('-M', '--max', type=float,
-        help='Use the value as the maximum for scaling')
+        help='Use this value as the maximum for scaling')
 
     help_emph = '''Emphasise input values below or above a certain
         threshold (e.g. "green:gt:5.0"). This option takes one argument
@@ -122,7 +125,7 @@ def main():
 
     for line in sparklines(
             numbers, num_lines=a.num_lines, emph=a.emphasise,
-            verbose=a.verbose, maximum=a.max):
+            verbose=a.verbose, minimum=a.min, maximum=a.max):
         print(line)
 
 

--- a/sparklines/sparklines.py
+++ b/sparklines/sparklines.py
@@ -76,12 +76,12 @@ def _check_emphasis(numbers, emph):
     return emphasized
 
 
-def scale_values(numbers, num_lines=1, maximum=None):
+def scale_values(numbers, num_lines=1, minimum=None, maximum=None):
     "Scale input numbers to appropriate range."
 
     # find min/max values, ignoring Nones
     filtered = [n for n in numbers if n is not None]
-    min_ = min(filtered)
+    min_ = min(filtered) if minimum is None else minimum
     max_ = max(filtered) if maximum is None else maximum
     dv = max_ - min_
 
@@ -110,12 +110,12 @@ def scale_values(numbers, num_lines=1, maximum=None):
     return values
 
 
-def sparklines(numbers=[], num_lines=1, emph=None, verbose=False, maximum=None):
+def sparklines(numbers=[], num_lines=1, emph=None, verbose=False, minimum=None, maximum=None):
     """
     Return a list of 'sparkline' strings for a given list of input numbers.
 
     The list of input numbers may contain None values, too, for which the
-    resulting sparkline will contain a blank character (a space). 
+    resulting sparkline will contain a blank character (a space).
 
     Examples:
 
@@ -136,7 +136,7 @@ def sparklines(numbers=[], num_lines=1, emph=None, verbose=False, maximum=None):
     # raise warning for negative numbers
     _check_negatives(numbers)
 
-    values = scale_values(numbers, num_lines=num_lines, maximum=maximum)
+    values = scale_values(numbers, num_lines=num_lines, minimum=minimum, maximum=maximum)
 
     # find values to be highlighted
     emphasized = _check_emphasis(numbers, emph) if emph else {}

--- a/test/test_sparkline.py
+++ b/test/test_sparkline.py
@@ -98,6 +98,22 @@ def test_maximum():
     exp = ['▁▄███']
     assert res == exp
 
+def test_maximum_internal_consistency():
+    res = sparklines([1, 2, 3, 10, 10, 1], maximum=3)
+    exp = sparklines([1, 2, 3, 3, 3, 1], maximum=3)
+    assert res == exp
+
+
+def test_minimum():
+    res = sparklines([0, 0, 11, 12, 13], minimum=10)
+    exp = ['▁▁▃▆█']
+    assert res == exp
+
+def test_minimum_internal_consistency():
+    res = sparklines([0, 0, 11, 12, 13], minimum=10)
+    exp = sparklines([10, 10, 11, 12, 13], minimum=10)
+    assert res == exp
+
 def test1():
     "Test single values all have the same four pixel high output character."
 


### PR DESCRIPTION
Values are clamped to the minimum.

**This change may break backward-compatability** if
sparklines was called with a positional argument
for maximum. This was done so that
minimum came before maximum in the argument list.
The change for maximums was added recently.