### PR TITLE
Stacked graphs

### DIFF
--- a/sparklines/__main__.py
+++ b/sparklines/__main__.py
@@ -108,12 +108,12 @@ def main():
     p.add_argument('nums', metavar='VALUE', type=test_valid_number,
         help=help_nums, nargs='*', default=sys.stdin)
 
-    help_roll = '''Start a new graph every PERIOD values and stack.
-    This is useful for data with natural periodicity: for
-    example daily or weekly.
+    help_wrap = '''Wrap the graph to a new line after PERIOD
+    data points. This is useful for data with natural periodicity:
+    for example daily or weekly.
     '''
-    p.add_argument('-r', '--roll', metavar='PERIOD', type=int,
-        help=help_roll)
+    p.add_argument('-w', '--wrap', metavar='PERIOD', type=int,
+        help=help_wrap)
 
     a = args = p.parse_args()
 
@@ -133,7 +133,7 @@ def main():
     for line in sparklines(
             numbers, num_lines=a.num_lines, emph=a.emphasise,
             verbose=a.verbose, minimum=a.min, maximum=a.max,
-            roll=args.roll):
+            wrap=args.wrap):
         print(line)
 
 

--- a/sparklines/__main__.py
+++ b/sparklines/__main__.py
@@ -108,6 +108,13 @@ def main():
     p.add_argument('nums', metavar='VALUE', type=test_valid_number,
         help=help_nums, nargs='*', default=sys.stdin)
 
+    help_roll = '''Start a new graph every PERIOD values and stack.
+    This is useful for data with natural periodicity: for
+    example daily or weekly.
+    '''
+    p.add_argument('-r', '--roll', metavar='PERIOD', type=int,
+        help=help_roll)
+
     a = args = p.parse_args()
 
     if args.version:
@@ -125,7 +132,8 @@ def main():
 
     for line in sparklines(
             numbers, num_lines=a.num_lines, emph=a.emphasise,
-            verbose=a.verbose, minimum=a.min, maximum=a.max):
+            verbose=a.verbose, minimum=a.min, maximum=a.max,
+            roll=args.roll):
         print(line)
 
 

--- a/sparklines/sparklines.py
+++ b/sparklines/sparklines.py
@@ -8,6 +8,8 @@ Please read the file README.rst for more information.
 """
 
 from __future__ import unicode_literals, print_function, division
+
+import itertools
 import re
 import sys
 import warnings
@@ -110,7 +112,8 @@ def scale_values(numbers, num_lines=1, minimum=None, maximum=None):
     return values
 
 
-def sparklines(numbers=[], num_lines=1, emph=None, verbose=False, minimum=None, maximum=None):
+def sparklines(numbers=[], num_lines=1, emph=None, verbose=False,
+        minimum=None, maximum=None, roll=None):
     """
     Return a list of 'sparkline' strings for a given list of input numbers.
 
@@ -158,7 +161,27 @@ def sparklines(numbers=[], num_lines=1, emph=None, verbose=False, minimum=None, 
             else:
                 res = [blocks[int(v)] if not v is None else ' ' for v in values]
             lines.append(''.join(res))
-        return lines
+
+        if roll:
+            return roll_lines(roll, lines)
+        else:
+            return lines
+
+
+def roll_lines(period, lines):
+    "Produce stacked mini-graphs"
+    parts_for_line = [roll_line(period, line) for line in lines]
+    lines_for_periods = list(map(list, zip(*parts_for_line)))
+
+    for period_lines in lines_for_periods:
+        period_lines.append("")
+
+    return list(itertools.chain.from_iterable(lines_for_periods))
+
+
+def roll_line(period, line):
+    for start in range(0, len(line), period):
+        yield line[start: start + period]
 
 
 def demo(nums=[]):

--- a/sparklines/sparklines.py
+++ b/sparklines/sparklines.py
@@ -113,7 +113,7 @@ def scale_values(numbers, num_lines=1, minimum=None, maximum=None):
 
 
 def sparklines(numbers=[], num_lines=1, emph=None, verbose=False,
-        minimum=None, maximum=None, roll=None):
+        minimum=None, maximum=None, wrap=None):
     """
     Return a list of 'sparkline' strings for a given list of input numbers.
 
@@ -148,7 +148,7 @@ def sparklines(numbers=[], num_lines=1, emph=None, verbose=False,
         multi_values = []
         for i in range(num_lines):
             multi_values.append([
-                min(v, 8) if not v is None else None 
+                min(v, 8) if not v is None else None
                 for v in values
             ])
             values = [max(0, v-8) if not v is None else None for v in values]
@@ -162,15 +162,15 @@ def sparklines(numbers=[], num_lines=1, emph=None, verbose=False,
                 res = [blocks[int(v)] if not v is None else ' ' for v in values]
             lines.append(''.join(res))
 
-        if roll:
-            return roll_lines(roll, lines)
+        if wrap:
+            return wrap_lines(wrap, lines)
         else:
             return lines
 
 
-def roll_lines(period, lines):
+def wrap_lines(period, lines):
     "Produce stacked mini-graphs"
-    parts_for_line = [roll_line(period, line) for line in lines]
+    parts_for_line = [wrap_line(period, line) for line in lines]
     lines_for_periods = list(map(list, zip(*parts_for_line)))
 
     for period_lines in lines_for_periods:
@@ -179,7 +179,7 @@ def roll_lines(period, lines):
     return list(itertools.chain.from_iterable(lines_for_periods))
 
 
-def roll_line(period, line):
+def wrap_line(period, line):
     for start in range(0, len(line), period):
         yield line[start: start + period]
 

--- a/test/test_sparkline.py
+++ b/test/test_sparkline.py
@@ -139,3 +139,9 @@ def test_multiline():
         " ▆█",
         "▁██"]
     assert res == exp
+
+
+def test_roll():
+    res = sparklines([1,2, 3, 1, 2, 3, 1, 2], roll=3)
+    exp = ["▁▄█", "", "▁▄█", "", "▁▄", ""]
+    assert res == exp

--- a/test/test_sparkline.py
+++ b/test/test_sparkline.py
@@ -141,7 +141,7 @@ def test_multiline():
     assert res == exp
 
 
-def test_roll():
-    res = sparklines([1,2, 3, 1, 2, 3, 1, 2], roll=3)
+def test_wrap():
+    res = sparklines([1,2, 3, 1, 2, 3, 1, 2], wrap=3)
     exp = ["▁▄█", "", "▁▄█", "", "▁▄", ""]
     assert res == exp


### PR DESCRIPTION
# Motivation

Many of the data sources I display with sparklines are in some way periodic. To understand what's going on it can be helpful to produce stacked periodic graphs.

For example, here is a subset of a graph of how many key presses I type per hour stack per day
 (imagine this has a fixed width font...)

▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▅0
▂▃▃▅▁▅▄▃█▄█▁▄███▅▁▁▁▁▁▁▁▁▁▁▁▂█52634
▁▁▂▃▂▂▅█▂▅██▁█▇██▆██▁▁▁▁▁▁▁▁▁▁▁▁68905
▂▁▁▃▂▁▁▆██▇█▁▇█▇█▄▁▁▁▁▁▁▁▁▁▁▁▄54345

# Prior work

R's **ggplot** provides similar features, http://docs.ggplot2.org/current/facet_grid.html, in the world of real graphs rather than hacky tools.

# Potential feature creep

This definitely counts as a "kitchen sink" feature and there may be strong arguments for not including it. When I've wanted to this before I've achieved it through hand-coding.

The arguments for having it in sparklines are:

* Making this useful approach discoverable to others
* Selfishly, I want to turn this into something I can run, and inside sparklines is a convenient place to put it.
* The stacked graphs want to share a common minimum and maximum

# Slippery slope

It might be worth considering not whether this feature represents feature-creep, but rather whether it is a member of a class of features (graph-compositors?) that belong in another tool.
The limited nature of ascii displays may somewhat limit what such a tool could do.

# As a bash one-liner

It's probably informative to compare the equivalent bash one liner for implementing this feature.
The less complex this seems to you the less strong the argument for placing this inside sparklines itself.

```bash
file=$(mktemp) ; cat  > "$file"; cat "$file" sparklines -m "$(sort -n $file | head -n 1)" -M "$(sort -n $file | tail -n 1) "
```

