### PR TITLE
Fix Issue #33

### DIFF
--- a/sparklines/sparklines.py
+++ b/sparklines/sparklines.py
@@ -35,7 +35,7 @@ def _check_negatives(numbers):
 def _check_emphasis(numbers, emph):
     """Find index postions in list of numbers to be emphasized according to emph."""
 
-    pat = "(\w+)\:(eq|gt|ge|lt|le)\:(.+)"
+    pat = r"(\w+)\:(eq|gt|ge|lt|le)\:(.+)"
     # find values to be highlighted
     emphasized = {}  # index: color
     for (i, n) in enumerate(numbers):


### PR DESCRIPTION
Warning goes away.

I did run the unit tests, on window I get this... but I didn't do anything with code related to that. I'm guessing it is not a cross platform unit test.

```
self = <encodings.cp1252.IncrementalDecoder object at 0x00000266205ECDD0>
input = b'Usage examples (command-line and programmatic use):\r\n\r\n- Standard one-line sparkline\r\nsparklines 3 1 4 1 5 9 2...6\x82\xe2\x96\x85 \xe2\x96\x85\xe2\x96\x82\xe2\x96\x88\xe2\x96\x84\xe2\x96\x81\xe2\x96\x84\xe2\x96\x81\xe2\x96\x83\r\n'
final = True

    def decode(self, input, final=False):
>       return codecs.charmap_decode(input,self.errors,decoding_table)[0]
E       UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 171: character maps to <undefined>

C:\Users\matth\AppData\Local\Programs\Python\Python311\Lib\encodings\cp1252.py:23: UnicodeDecodeError
================================================ short test summary info =================================================
FAILED tests/test_sparkline.py::test_demo_consistency - UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 171: character maps to <undefined>
```