### PR TITLE
Resolve SyntaxWarning on py312+

### DIFF
--- a/sparklines/__main__.py
+++ b/sparklines/__main__.py
@@ -52,7 +52,7 @@ def test_valid_number(arg):
 def test_valid_emphasis(arg):
     """Argparse validator for color filter expressions."""
 
-    pat = "\w+\:(eq|gt|ge|lt|le)\:.+"
+    pat = r"\w+\:(eq|gt|ge|lt|le)\:.+"
     if re.match(pat, arg):
         return arg
     else:


### PR DESCRIPTION
```console
$ echo '1 2 3 4 5' | sparklines -e 'green:gt:2.0'
/Users/mxr/src/mxr/sparklines/sparklines/__main__.py:55: SyntaxWarning: invalid escape sequence '\w'
  pat = "\w+\:(eq|gt|ge|lt|le)\:.+"
▁▃▄▆█
```

Related issue: #33