### PR TITLE
Fetch version from setup.py instead of hardcoding

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -29,6 +29,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        python -m pip install -e .
     - name: Test with pytest
       run: |
         pytest tests

--- a/sparklines/__main__.py
+++ b/sparklines/__main__.py
@@ -8,6 +8,7 @@ import argparse
 import importlib.util
 import re
 import sys
+from importlib.metadata import version
 
 if importlib.util.find_spec("termcolor"):
     HAVE_TERMCOLOR = True
@@ -59,7 +60,7 @@ def test_valid_emphasis(arg):
         raise ValueError()
 
 
-def main():
+def main(argv=None):
     desc = """Sparklines on the command-line, e.g. ▃▁▄▁▄█▂▅ for
         3 1 4 1 5 9 2 6. Please add bug reports and suggestions to
         https://github.com/deeplook/sparklines/issues."""
@@ -73,7 +74,11 @@ def main():
     )
 
     p.add_argument(
-        "-V", "--version", action="store_true", help="Display version number and quit."
+        "-V",
+        "--version",
+        action="version",
+        help="Display version number and quit.",
+        version=version("sparklines"),
     )
 
     help_d = """Show a few usage examples for given (mandatory) input
@@ -130,11 +135,7 @@ def main():
     """
     p.add_argument("-w", "--wrap", metavar="PERIOD", type=int, help=help_wrap)
 
-    a = args = p.parse_args()
-
-    if args.version:
-        print("0.4.2")  # FIXME: needs to be taken again from setup.py...
-        sys.exit()
+    a = args = p.parse_args(argv)
 
     numbers = args.nums
     if numbers == sys.stdin:

--- a/tests/test_sparkline.py
+++ b/tests/test_sparkline.py
@@ -7,11 +7,12 @@ Run from the root folder with either 'python setup.py test' or
 
 import os
 import re
+from pathlib import Path
 
 import pytest
 
 from sparklines import batch, scale_values, sparklines, demo
-from sparklines.__main__ import test_valid_number as is_valid_number
+from sparklines.__main__ import test_valid_number as is_valid_number, main
 
 
 def strip_ansi(text):
@@ -227,3 +228,17 @@ def test_demo_consistency():
             stream.write(res.encode("utf8"))
 
     assert exp == res, "Demo output has changed. Verify it and update demo-output!"
+
+
+def test_main_version(capsys):
+    setup_py = Path(__file__).parent.parent / "setup.py"
+    match = re.search('version="(.+)"', setup_py.read_text())
+    assert match
+    expected_version = match.group(1)
+
+    with pytest.raises(SystemExit) as excinfo:
+        main(("--version",))
+    assert excinfo.value.code == 0
+
+    out, _ = capsys.readouterr()
+    assert out == f"{expected_version}\n"


### PR DESCRIPTION
Added a test and also verified locally:

```console
$ pytest -k main_version tests/test_sparkline.py
<snip>
collected 22 items / 21 deselected / 1 selected                                                                                             

 tests/test_sparkline.py ✓                                                                                                    100% ██████████

Results (0.03s):
       1 passed
      21 deselected
$ sparklines --version
0.5.0
```

Resolves #35