### PR TITLE
fix: graceful fallback in ideal_num_rows for irrational ratios

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -64,6 +64,8 @@
   'none' omits zeros from both sides.
 - Removed inverted=True / -i/--inverted and split=True / -s/--split from the
   public API. Inverted rendering is now an internal implementation detail.
+- Removed -v/--verbose CLI flag and verbose= parameter (were no-ops since
+  introduction; never produced any output).
 - Proportional row allocation: up_rows/total == pos_max/range, so the zero
   line stays meaningful as the visual boundary between halves.
 - ANSI reverse video with complement block characters gives full 8-level

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -3,3 +3,4 @@ Tal Wrii <talwrii@googlemail.com>
 Michael Gisi <gisi@umich.edu>
 aldencolerain
 Max R
+Seth Livingston <sethlivingston>

--- a/sparklines/sparklines.py
+++ b/sparklines/sparklines.py
@@ -156,12 +156,21 @@ def allocate_rows(pos_max: float, neg_max: float, n: int) -> tuple[int, int]:
 
 
 def ideal_num_rows(pos_max: float, neg_max: float) -> int:
-    """Return the smallest total row count that yields an exactly proportional split."""
+    """Return the smallest total row count that yields an exactly proportional split.
+
+    Falls back to the closest approximation within 10 rows if no exact split exists.
+    """
+    best_n = 2
+    best_imbalance = float("inf")
     for n in range(2, 101):
         i, j = allocate_rows(pos_max, neg_max, n)
         if proportional(pos_max, neg_max, i, j):
             return n
-    raise ValueError("no proportional row count found within 101 rows")
+        imbalance = abs(pos_max * j - neg_max * i)
+        if imbalance < best_imbalance and n <= 10:
+            best_imbalance = imbalance
+            best_n = n
+    return best_n
 
 
 def resolve_mixed_rows(

--- a/tests/test_sparkline.py
+++ b/tests/test_sparkline.py
@@ -463,6 +463,15 @@ def test_auto_split_per_side_scale() -> None:
 # ---------------------------------------------------------------------------
 
 
+def test_auto_irrational_ratio() -> None:
+    # irrational pos/neg ratio — ideal_num_rows has no exact solution,
+    # should fall back gracefully rather than raising ValueError
+    import math
+
+    res = sparklines([1, -(math.sqrt(2))], num_lines="auto")
+    assert 2 <= len(res) <= 10
+
+
 def test_num_lines_auto_cli(capsys: pytest.CaptureFixture[str]) -> None:
     main(["-n", "auto", "1", "2", "3", "-1", "-2", "-3", "0", "4", "5", "6"])
     out, _ = capsys.readouterr()

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.9"
 
 [[package]]
@@ -79,7 +79,7 @@ wheels = [
 
 [[package]]
 name = "sparklines"
-version = "0.7.0"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "termcolor" },


### PR DESCRIPTION
## Summary

- `ideal_num_rows`: fall back to best approximation within a 10-row search cap instead of raising `ValueError` when no exact proportional split exists (e.g. irrational pos/neg ratios with `num_lines='auto'`)
- Add `test_auto_irrational_ratio` to cover the fallback path
- `CHANGELOG`: document removal of `-v/--verbose` (was always a no-op since introduction)
- `CONTRIBUTORS`: add Seth Livingston (sethlivingston)

## Test plan

- [x] `uv run python -m pytest tests/` — all 50 tests pass
- [x] `sparklines([1, -1.4142135623730951], num_lines='auto')` no longer raises `ValueError`